### PR TITLE
Dark mode: Colour asset for iOS 13 and above light and dark mode 

### DIFF
--- a/iosconfsg2019/Assets.xcassets/Theme Colours/Contents.json
+++ b/iosconfsg2019/Assets.xcassets/Theme Colours/Contents.json
@@ -1,0 +1,6 @@
+{
+  "info" : {
+    "version" : 1,
+    "author" : "xcode"
+  }
+}

--- a/iosconfsg2019/Assets.xcassets/Theme Colours/Theme Primary Label Colour.colorset/Contents.json
+++ b/iosconfsg2019/Assets.xcassets/Theme Colours/Theme Primary Label Colour.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "info" : {
+    "version" : 1,
+    "author" : "xcode"
+  },
+  "colors" : [
+    {
+      "idiom" : "universal",
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "red" : "0.579",
+          "alpha" : "1.000",
+          "blue" : "0.573",
+          "green" : "0.128"
+        }
+      }
+    },
+    {
+      "idiom" : "universal",
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "red" : "1.000",
+          "alpha" : "1.000",
+          "blue" : "0.000",
+          "green" : "0.576"
+        }
+      }
+    }
+  ]
+}

--- a/iosconfsg2019/Helpers/StyleSheet.swift
+++ b/iosconfsg2019/Helpers/StyleSheet.swift
@@ -46,7 +46,7 @@ fileprivate class iOS13AndAbove: StyleSheetProtocol {
     }
     
     var primaryLabelColor: UIColor {
-        return .purple
+        return UIColor(named: "Theme Primary Label Colour") ?? .purple
     }
     
     var secondaryLabelColor: UIColor {

--- a/iosconfsg2019/Schedule Tab/DetailGraphqlViewController.swift
+++ b/iosconfsg2019/Schedule Tab/DetailGraphqlViewController.swift
@@ -21,7 +21,7 @@ class DetailGraphqlViewController: BaseViewController {
             self.speakerTwitter.text = twitter
             self.speakerTwitter.attributer = twitter.matchMentions.makeInteract({ (link) in
                 UIApplication.shared.open(URL(string: "https://twitter.com/\(link.replacingOccurrences(of: "@", with: ""))")!, options: [:], completionHandler: { completed in })
-            }).setLinkColor(UIColor.purple).size(UIFont.largeSize)
+            }).setLinkColor(StyleSheet.shared.theme.primaryLabelColor).size(UIFont.largeSize)
             self.speakerTwitter.setContentOffset(.zero, animated: false)
 
             if let imageName = talk?.speakerImage {

--- a/iosconfsg2019/Schedule Tab/FeedbackViewController.swift
+++ b/iosconfsg2019/Schedule Tab/FeedbackViewController.swift
@@ -117,7 +117,7 @@ class FeedbackViewController: BaseViewController {
         btn.setTitle("Send", for: .normal)
         btn.setTitleColor(UIColor.white, for: .normal)
         btn.translatesAutoresizingMaskIntoConstraints = false
-        btn.backgroundColor = UIColor.purple
+        btn.backgroundColor = StyleSheet.shared.theme.primaryLabelColor
         return btn
     }()
 

--- a/iosconfsg2019/Schedule Tab/ScheduleGraphqlViewController.swift
+++ b/iosconfsg2019/Schedule Tab/ScheduleGraphqlViewController.swift
@@ -145,7 +145,7 @@ class HeaderTableView: UIView {
     private func setupView(items: [String]) {
         daySegmentControl = UISegmentedControl(items: items)
         daySegmentControl.translatesAutoresizingMaskIntoConstraints = false
-        daySegmentControl.tintColor = UIColor.purple
+        daySegmentControl.tintColor = StyleSheet.shared.theme.primaryLabelColor
         daySegmentControl.backgroundColor = StyleSheet.shared.theme.secondaryBackgroundColor
         addSubview(daySegmentControl)
         addConstraintsWithFormat("H:|-16-[v0]-16-|", views: daySegmentControl)

--- a/iosconfsg2019/Setup/CustomAlertViewController.swift
+++ b/iosconfsg2019/Setup/CustomAlertViewController.swift
@@ -19,7 +19,7 @@ class CustomAlertViewController: BaseViewController {
         tv.showsVerticalScrollIndicator = true
         tv.translatesAutoresizingMaskIntoConstraints = false
         tv.text = "Some description"
-        tv.backgroundColor = UIColor.purple
+        tv.backgroundColor = StyleSheet.shared.theme.primaryLabelColor
         tv.isSelectable = false
         tv.layer.cornerRadius = 10
         tv.contentInset = UIEdgeInsets(top: 12, left: 12, bottom: 12, right: 12)

--- a/iosconfsg2019/Setup/CustomTabBarController.swift
+++ b/iosconfsg2019/Setup/CustomTabBarController.swift
@@ -43,7 +43,7 @@ class CustomTabBarController: UITabBarController {
         
         tabBar.layer.addSublayer(topBorder)
         tabBar.clipsToBounds = true
-        tabBar.tintColor = UIColor.purple
+        tabBar.tintColor = StyleSheet.shared.theme.primaryLabelColor
     }
 }
 

--- a/iosconfsg2019/Setup/WelcomeViewController.swift
+++ b/iosconfsg2019/Setup/WelcomeViewController.swift
@@ -53,7 +53,7 @@ class WelcomeViewController: BaseViewController {
         let btn = UIButton(type: UIButton.ButtonType.system)
         btn.translatesAutoresizingMaskIntoConstraints = false
         btn.setTitle("Allow Notifications", for: .normal)
-        btn.setTitleColor(UIColor.purple, for: .normal)
+        btn.setTitleColor(StyleSheet.shared.theme.primaryLabelColor, for: .normal)
         btn.backgroundColor = UIColor.init(white: 0.9, alpha: 1)
         btn.addTarget(self, action: #selector(requestNotificationPermission), for: .touchUpInside)
         return btn
@@ -127,7 +127,7 @@ class WelcomeViewController: BaseViewController {
     }
     
     private func setupViews() {
-        view.backgroundColor = UIColor.purple
+        view.backgroundColor = StyleSheet.shared.theme.primaryLabelColor
         
         view.addSubview(confImage)
         view.addSubview(titleLabel)


### PR DESCRIPTION
- Add colour assets to set Orange colour for dark mode and Purple colour for light mode.
- Update primary colour for tabbar, feedback and welcome screens.

### Screenshots

![Simulator Screen Shot - iPhone Xs - 2020-01-07 at 10 03 50](https://user-images.githubusercontent.com/3436520/71864634-45acb780-313b-11ea-9d16-bd533fabb128.png)
![Simulator Screen Shot - iPhone Xs - 2020-01-07 at 10 04 06](https://user-images.githubusercontent.com/3436520/71864635-45acb780-313b-11ea-8dcf-a91af2aadc78.png)
